### PR TITLE
Fix paths in manifest, extract base path in install script to avoid MANIFEST_URL_ERROR

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -2,11 +2,11 @@
   "version": "0.1",
   "name": "Open Web App",
   "description": "Your new awesome Open Web App",
-  "launch_path": "/app-template/index.html",
+  "launch_path": "/mdn-app-template/index.html",
   "icons": {
-    "16": "/app-template/app-icons/icon-16.png",
-    "48": "/app-template/app-icons/icon-48.png",
-    "128": "/app-template/app-icons/icon-128.png"
+    "16": "/mdn-app-template/app-icons/icon-16.png",
+    "48": "/mdn-app-template/app-icons/icon-48.png",
+    "128": "/mdn-app-template/app-icons/icon-128.png"
   },
   "developer": {
     "name": "Your Name",

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -1,4 +1,12 @@
-var manifest_url = location.href + 'manifest.webapp';
+var manifest_url = basepath(location.href) + 'manifest.webapp';
+
+function basepath(path) {
+  // make sure we omit 
+  var i = path.lastIndexOf('/')
+  if (i !== -1 && i !== path.length - 1)
+    return path.substr(0, i + 1);
+  return path;
+}
 
 function install(ev) {
   ev.preventDefault();

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -1,8 +1,8 @@
 var manifest_url = basepath(location.href) + 'manifest.webapp';
 
 function basepath(path) {
-  // make sure we omit 
-  var i = path.lastIndexOf('/')
+  // make sure we omit path segments that do not map to directories
+  var i = path.lastIndexOf('/');
   if (i !== -1 && i !== path.length - 1)
     return path.substr(0, i + 1);
   return path;


### PR DESCRIPTION
This PR makes sure the manifest URL is valid by rebasing the location.href to the last directory. In fact, if the user launches the app on `/mdn-app-template/index.html` instead of `/mdn-app-template/`, the app fails to install with an obscure `MANIFEST_URL_ERROR`. I also fixed paths in manifest to match the repo name.
